### PR TITLE
Restyle bot difficulty controls as per-player rows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -278,15 +278,30 @@ h1 img{
   color: #fff;
 }
 
+.bot-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bot-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+}
+
 .bot-player-label {
   font-family: 'IM Fell English SC', serif;
   font-size: 0.8em;
-  color: rgba(232, 201, 122, 0.55);
-  padding: 0 2px 0 6px;
+  font-weight: bold;
+  width: 22px;
+  text-align: right;
+  flex-shrink: 0;
 }
-.bot-player-label:first-child {
-  padding-left: 0;
-}
+.bot-p2 { color: #8a5050; }
+.bot-p3 { color: #3d7a4a; }
+.bot-p4 { color: #6b4a8a; }
 
 /* ── Hex map layout ───────────────────────────── */
 .map.hex-mode {

--- a/index.html
+++ b/index.html
@@ -40,22 +40,28 @@
       </div>
       <div class="setup-group" id="bot-controls">
         <span class="setup-label">Bots</span>
-        <div class="setup-btns">
-          <span class="bot-player-label">P2</span>
-          <button class="bot-btn active" data-player="2" data-diff="off">Off</button>
-          <button class="bot-btn" data-player="2" data-diff="easy">Easy</button>
-          <button class="bot-btn" data-player="2" data-diff="medium">Med</button>
-          <button class="bot-btn" data-player="2" data-diff="hard">Hard</button>
-          <span class="bot-player-label p3-control">P3</span>
-          <button class="bot-btn p3-control active" data-player="3" data-diff="off">Off</button>
-          <button class="bot-btn p3-control" data-player="3" data-diff="easy">Easy</button>
-          <button class="bot-btn p3-control" data-player="3" data-diff="medium">Med</button>
-          <button class="bot-btn p3-control" data-player="3" data-diff="hard">Hard</button>
-          <span class="bot-player-label p4-control">P4</span>
-          <button class="bot-btn p4-control active" data-player="4" data-diff="off">Off</button>
-          <button class="bot-btn p4-control" data-player="4" data-diff="easy">Easy</button>
-          <button class="bot-btn p4-control" data-player="4" data-diff="medium">Med</button>
-          <button class="bot-btn p4-control" data-player="4" data-diff="hard">Hard</button>
+        <div class="bot-rows">
+          <div class="bot-row">
+            <span class="bot-player-label bot-p2">P2</span>
+            <button class="bot-btn active" data-player="2" data-diff="off">Off</button>
+            <button class="bot-btn" data-player="2" data-diff="easy">Easy</button>
+            <button class="bot-btn" data-player="2" data-diff="medium">Med</button>
+            <button class="bot-btn" data-player="2" data-diff="hard">Hard</button>
+          </div>
+          <div class="bot-row p3-control">
+            <span class="bot-player-label bot-p3">P3</span>
+            <button class="bot-btn active" data-player="3" data-diff="off">Off</button>
+            <button class="bot-btn" data-player="3" data-diff="easy">Easy</button>
+            <button class="bot-btn" data-player="3" data-diff="medium">Med</button>
+            <button class="bot-btn" data-player="3" data-diff="hard">Hard</button>
+          </div>
+          <div class="bot-row p4-control">
+            <span class="bot-player-label bot-p4">P4</span>
+            <button class="bot-btn active" data-player="4" data-diff="off">Off</button>
+            <button class="bot-btn" data-player="4" data-diff="easy">Easy</button>
+            <button class="bot-btn" data-player="4" data-diff="medium">Med</button>
+            <button class="bot-btn" data-player="4" data-diff="hard">Hard</button>
+          </div>
         </div>
       </div>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -800,9 +800,9 @@ class Game {
 
   function updateBotControlVisibility(numPlayers) {
     document.querySelectorAll('.p3-control').forEach(el =>
-      el.style.display = numPlayers >= 3 ? 'inline-block' : 'none');
+      el.style.display = numPlayers >= 3 ? 'flex' : 'none');
     document.querySelectorAll('.p4-control').forEach(el =>
-      el.style.display = numPlayers >= 4 ? 'inline-block' : 'none');
+      el.style.display = numPlayers >= 4 ? 'flex' : 'none');
   }
 
   document.querySelectorAll('.player-btn').forEach(btn => {


### PR DESCRIPTION
Closes #15

## Summary
- Each player's bot controls now render as a self-contained row: `[P2] [Off] [Easy] [Med] [Hard]`
- `p3-control` / `p4-control` classes moved from individual buttons/spans to the `.bot-row` div
- `updateBotControlVisibility()` updated to use `display: flex` (was `inline-block`, which broke row layout)
- Player labels are color-coded: P2 red, P3 green, P4 purple — matching in-game player themes
- Fixed-width label column keeps button groups left-aligned across all rows

## Test plan
- [ ] 2-player mode: only P2 row visible
- [ ] 3-player mode: P2 and P3 rows visible
- [ ] 4-player mode: all three rows visible
- [ ] Switching difficulty still works for all players
- [ ] Layout is clean at all breakpoints