### PR TITLE
Add proportional island score bar (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Island Pillagers are documented here.
 
+## [1.1.0] - 2026-03-04
+
+### Added
+- Proportional island score bar spanning the full game width
+- Bar segments colored per player (matching island colors) plus an unclaimed segment
+- Segments animate smoothly on width changes; unused player slots hidden automatically
+
 ## [1.0.3] - 2026-03-04
 
 ### Changed

--- a/css/style.css
+++ b/css/style.css
@@ -313,6 +313,29 @@ h1 img{
 .bot-p3 { color: #3d7a4a; }
 .bot-p4 { color: #6b4a8a; }
 
+/* ── Score bar ─────────────────────────────────── */
+#score-bar {
+  flex: 0 0 100%;
+  display: flex;
+  height: 14px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 0 0 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.score-segment {
+  height: 100%;
+  width: 0;
+  transition: width 0.4s ease;
+}
+
+#seg-player1   { background: linear-gradient(90deg, #3a5260, #a0b4c0); }
+#seg-player2   { background: linear-gradient(90deg, #7a1a08, #e05530); }
+#seg-player3   { background: linear-gradient(90deg, #0e7490, #22d3ee); }
+#seg-player4   { background: linear-gradient(90deg, #581c87, #c084fc); }
+#seg-unclaimed { background: rgba(255, 255, 255, 0.12); }
+
 /* ── Hex map layout ───────────────────────────── */
 .map.hex-mode {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -65,6 +65,13 @@
         </div>
       </div>
     </div>
+    <div id="score-bar">
+      <div class="score-segment" id="seg-player1"></div>
+      <div class="score-segment" id="seg-player2"></div>
+      <div class="score-segment" id="seg-player3"></div>
+      <div class="score-segment" id="seg-player4"></div>
+      <div class="score-segment" id="seg-unclaimed"></div>
+    </div>
     <div class="map"></div>
     <div class="side-bar">
       <button class="button" id="end-phase-btn">⚔ End Attack</button>

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,13 @@
 'use strict';
 
-const VERSION = '1.0.3';
+const VERSION = '1.1.0';
 
 const CHANGELOG = `
+  <h3>v1.1.0 — 2026-03-04</h3>
+  <ul>
+    <li>Proportional island score bar below the setup strip</li>
+    <li>Bar updates live: player segments + unclaimed territory, supports 2–4 players</li>
+  </ul>
   <h3>v1.0.3 — 2026-03-04</h3>
   <ul>
     <li>Setup strip grouped into labeled sections (Map Size, Players, Shape, Bots)</li>
@@ -615,6 +620,25 @@ class Game {
         ? `<p>${label}: <em>eliminated</em></p>`
         : `<p>${label}: ${count} island${count !== 1 ? 's' : ''}</p>`;
     }).join('');
+
+    // Score bar — proportional segments per player + unclaimed
+    const total = this.gridSize;
+    let claimed = 0;
+
+    ['player1', 'player2', 'player3', 'player4'].forEach(pk => {
+      const seg = document.getElementById('seg-' + pk);
+      if (!this.playerKeys.includes(pk)) {
+        seg.style.display = 'none';
+        return;
+      }
+      seg.style.display = '';
+      const count = document.querySelectorAll('.' + pk).length;
+      claimed += count;
+      seg.style.width = (count / total * 100).toFixed(2) + '%';
+    });
+
+    document.getElementById('seg-unclaimed').style.width =
+      ((total - claimed) / total * 100).toFixed(2) + '%';
   }
 
   // ── Online ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #20
Closes #21

## Summary
- Full-width `#score-bar` placed between the setup strip and the map
- Five segments: one per player (colored to match their islands) + an unclaimed segment
- `updateScores()` calculates each player's island percentage and sets segment widths
- Unused player slots (`player3`/`player4` in a 2-player game) are hidden via `display:none`
- 0.4s CSS transition makes the bar animate smoothly on every territory change
- Bump to **v1.1.0** — new user-visible feature

## Test plan
- [ ] Bar fills 100% of width at game start (2 corners claimed, rest unclaimed)
- [ ] Segments update after each attack and after rebuild phase
- [ ] Eliminated players collapse to 0% smoothly
- [ ] 2-player game hides player3/player4 segments
- [ ] 3 and 4-player games show the correct segments
- [ ] Looks correct at mobile and desktop widths