### PR TITLE
Base scores and score bar on total units (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Island Pillagers are documented here.
 
+## [1.1.1] - 2026-03-04
+
+### Changed
+- Scores and score bar now based on total units owned, not island count
+- Removed unclaimed segment from score bar (units are always player-owned)
+
 ## [1.1.0] - 2026-03-04
 
 ### Added

--- a/css/style.css
+++ b/css/style.css
@@ -330,11 +330,10 @@ h1 img{
   transition: width 0.4s ease;
 }
 
-#seg-player1   { background: linear-gradient(90deg, #3a5260, #a0b4c0); }
-#seg-player2   { background: linear-gradient(90deg, #7a1a08, #e05530); }
-#seg-player3   { background: linear-gradient(90deg, #0e7490, #22d3ee); }
-#seg-player4   { background: linear-gradient(90deg, #581c87, #c084fc); }
-#seg-unclaimed { background: rgba(255, 255, 255, 0.12); }
+#seg-player1 { background: linear-gradient(90deg, #3a5260, #a0b4c0); }
+#seg-player2 { background: linear-gradient(90deg, #7a1a08, #e05530); }
+#seg-player3 { background: linear-gradient(90deg, #0e7490, #22d3ee); }
+#seg-player4 { background: linear-gradient(90deg, #581c87, #c084fc); }
 
 /* ── Hex map layout ───────────────────────────── */
 .map.hex-mode {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,6 @@
       <div class="score-segment" id="seg-player2"></div>
       <div class="score-segment" id="seg-player3"></div>
       <div class="score-segment" id="seg-player4"></div>
-      <div class="score-segment" id="seg-unclaimed"></div>
     </div>
     <div class="map"></div>
     <div class="side-bar">

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const VERSION = '1.1.0';
+const VERSION = '1.1.1';
 
 const CHANGELOG = `
+  <h3>v1.1.1 — 2026-03-04</h3>
+  <ul>
+    <li>Scores and score bar now based on total units, not island count</li>
+  </ul>
   <h3>v1.1.0 — 2026-03-04</h3>
   <ul>
     <li>Proportional island score bar below the setup strip</li>
@@ -613,32 +617,33 @@ class Game {
   }
 
   updateScores() {
+    const unitCount = pk => Array.from(document.querySelectorAll('.' + pk))
+      .reduce((sum, el) => {
+        const n = parseInt(el.querySelector('h2')?.textContent.trim(), 10);
+        return sum + (isNaN(n) ? 0 : n);
+      }, 0);
+
+    const playerUnits = Object.fromEntries(this.playerKeys.map(pk => [pk, unitCount(pk)]));
+    const totalUnits  = Object.values(playerUnits).reduce((a, b) => a + b, 0);
+
+    // Text scores
     document.querySelector('.scores').innerHTML = this.playerKeys.map(pk => {
-      const count = document.querySelectorAll('.' + pk).length;
+      const units = playerUnits[pk];
       const label = this.players[pk].name;
-      return count === 0
+      return units === 0
         ? `<p>${label}: <em>eliminated</em></p>`
-        : `<p>${label}: ${count} island${count !== 1 ? 's' : ''}</p>`;
+        : `<p>${label}: ${units} unit${units !== 1 ? 's' : ''}</p>`;
     }).join('');
 
-    // Score bar — proportional segments per player + unclaimed
-    const total = this.gridSize;
-    let claimed = 0;
-
+    // Score bar — proportional by units owned
     ['player1', 'player2', 'player3', 'player4'].forEach(pk => {
       const seg = document.getElementById('seg-' + pk);
-      if (!this.playerKeys.includes(pk)) {
-        seg.style.display = 'none';
-        return;
-      }
+      if (!this.playerKeys.includes(pk)) { seg.style.display = 'none'; return; }
       seg.style.display = '';
-      const count = document.querySelectorAll('.' + pk).length;
-      claimed += count;
-      seg.style.width = (count / total * 100).toFixed(2) + '%';
+      seg.style.width = totalUnits > 0
+        ? (playerUnits[pk] / totalUnits * 100).toFixed(2) + '%'
+        : (100 / this.playerKeys.length).toFixed(2) + '%';
     });
-
-    document.getElementById('seg-unclaimed').style.width =
-      ((total - claimed) / total * 100).toFixed(2) + '%';
   }
 
   // ── Online ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #23

## Summary
- `updateScores()` now sums pirate units per player instead of counting islands owned
- Text scores display "X units" instead of "X islands"
- Score bar segments sized proportionally by unit count; equal split at game start before any hiring
- Removed `#seg-unclaimed` from HTML and CSS — all units belong to a player, no unclaimed segment needed
- Bump to v1.1.1

## Test plan
- [ ] Score panel shows unit counts, not island counts
- [ ] Score bar reflects unit distribution, not territory count
- [ ] Bar shifts after hire phase as units are added
- [ ] Eliminated players show "eliminated" and collapse to 0% in bar
- [ ] 2/3/4 player games all work correctly