### PR TITLE
Add Fortified Islands mode v1.2.0 (#24)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -264,8 +264,8 @@ h1 img{
   gap: 5px;
 }
 
-/* Shared button base — all four types consolidated */
-.size-btn, .player-btn, .shape-btn, .bot-btn {
+/* Shared button base — all five types consolidated */
+.size-btn, .player-btn, .shape-btn, .island-btn, .bot-btn {
   font-family: 'IM Fell English SC', serif;
   font-size: 0.85em;
   padding: 5px 14px;
@@ -276,14 +276,14 @@ h1 img{
   box-shadow: inset 0 0 8px 1px rgba(0,0,0,0.5);
   color: #1a1a1a;
 }
-.size-btn:hover, .player-btn:hover, .shape-btn:hover, .bot-btn:hover {
+.size-btn:hover, .player-btn:hover, .shape-btn:hover, .island-btn:hover, .bot-btn:hover {
   background-color: darkgoldenrod;
   color: #fff;
 }
-.size-btn:active, .player-btn:active, .shape-btn:active, .bot-btn:active {
+.size-btn:active, .player-btn:active, .shape-btn:active, .island-btn:active, .bot-btn:active {
   transform: translate(2px, 2px);
 }
-.size-btn.active, .player-btn.active, .shape-btn.active, .bot-btn.active {
+.size-btn.active, .player-btn.active, .shape-btn.active, .island-btn.active, .bot-btn.active {
   background-color: darkgoldenrod;
   color: #fff;
 }
@@ -601,7 +601,7 @@ h1 img{
     padding: 5px 8px 6px;
   }
 
-  .size-btn, .bot-btn, .player-btn, .shape-btn {
+  .size-btn, .bot-btn, .player-btn, .shape-btn, .island-btn {
     padding: 4px 10px;
     font-size: 0.8em;
   }
@@ -616,5 +616,5 @@ h1 img{
 @media (max-width: 400px) {
   #setup { gap: 5px; }
   .setup-group { padding: 4px 6px 5px; }
-  .size-btn, .bot-btn, .player-btn, .shape-btn { padding: 3px 7px; font-size: 0.75em; }
+  .size-btn, .bot-btn, .player-btn, .shape-btn, .island-btn { padding: 3px 7px; font-size: 0.75em; }
 }

--- a/index.html
+++ b/index.html
@@ -38,6 +38,13 @@
           <button class="shape-btn" data-shape="triangle">Triangle</button>
         </div>
       </div>
+      <div class="setup-group">
+        <span class="setup-label">Islands</span>
+        <div class="setup-btns">
+          <button class="island-btn active" data-mode="open">Open</button>
+          <button class="island-btn" data-mode="fortified">Fortified</button>
+        </div>
+      </div>
       <div class="setup-group" id="bot-controls">
         <span class="setup-label">Bots</span>
         <div class="bot-rows">

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const VERSION = '1.1.1';
+const VERSION = '1.2.0';
 
 const CHANGELOG = `
+  <h3>v1.2.0 — 2026-03-05</h3>
+  <ul>
+    <li>Fortified Islands mode: unclaimed spaces start with 1–6 random defenders</li>
+  </ul>
   <h3>v1.1.1 — 2026-03-04</h3>
   <ul>
     <li>Scores and score bar now based on total units, not island count</li>
@@ -50,6 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentBotDiffs   = { player2: 'off', player3: 'off', player4: 'off' };
   let currentNumPlayers = 2;
   let currentShape      = 'square';
+  let currentIslandMode = 'open';
   let activeGame        = null;
 
   function startGame(cols) {
@@ -72,12 +77,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const freshBtn = btnEl.cloneNode(true);
     btnEl.parentNode.replaceChild(freshBtn, btnEl);
 
-    activeGame = new Game(cols, currentBotDiffs, currentNumPlayers, currentShape);
+    activeGame = new Game(cols, currentBotDiffs, currentNumPlayers, currentShape, currentIslandMode);
     activeGame.init();
   }
 
 class Game {
-  constructor(cols = 4, diff = {}, numPlayers = 2, shape = 'square') {
+  constructor(cols = 4, diff = {}, numPlayers = 2, shape = 'square', islandMode = 'open') {
     this.cols      = cols;
     this.gridSize  = cols * cols;
     this.numPlayers         = numPlayers;
@@ -92,7 +97,8 @@ class Game {
     this.clickedUnits1      = 0;
     this.clickedUnits2      = 0;
     this.newSoldiers        = 0;
-    this.shape              = shape;       // 'square' | 'hex'
+    this.shape              = shape;       // 'square' | 'hex' | 'triangle'
+    this.islandMode         = islandMode; // 'open' | 'fortified'
     this.botDiffs           = { ...diff }; // per-player difficulty map
     this.botActive          = true;       // set false on game reset to cancel pending timeouts
 
@@ -216,6 +222,14 @@ class Game {
       el.classList.add(pk);
       el.innerHTML = '<h2>2</h2>';
     });
+
+    // Fortified mode: seed each unclaimed space with 1–6 random defenders
+    if (this.islandMode === 'fortified') {
+      document.querySelectorAll('.space').forEach(el => {
+        if (this.playerKeys.some(pk => el.classList.contains(pk))) return;
+        el.innerHTML = `<h2>${Math.ceil(Math.random() * 6)}</h2>`;
+      });
+    }
   }
 
   init() {
@@ -856,6 +870,15 @@ class Game {
     btn.addEventListener('click', () => {
       currentShape = btn.dataset.shape;
       document.querySelectorAll('.shape-btn').forEach(b =>
+        b.classList.toggle('active', b === btn));
+      startGame(currentCols);
+    });
+  });
+
+  document.querySelectorAll('.island-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentIslandMode = btn.dataset.mode;
+      document.querySelectorAll('.island-btn').forEach(b =>
         b.classList.toggle('active', b === btn));
       startGame(currentCols);
     });


### PR DESCRIPTION
## Summary
- Adds an **Islands** setup group (Open / Fortified) to the setup strip
- In Fortified mode, every unclaimed space starts with 1–6 random defenders, forcing players to fight for territory from turn one
- Open mode preserves current behaviour (unclaimed spaces start at 0)

## Implementation
- `index.html`: new Islands setup group with Open/Fortified buttons
- `js/app.js`: `currentIslandMode` module variable; passed to `Game` constructor as `islandMode`; `buildGrid()` seeds unclaimed spaces after corner placement; `.island-btn` listeners wired (same pattern as other setup buttons)
- `css/style.css`: `.island-btn` added to all shared button selector groups including responsive breakpoints
- Score bar unaffected — `updateScores()` only counts player-owned units

## Test plan
- [ ] Open mode: unclaimed spaces show 0, free to claim (no dice roll)
- [ ] Fortified mode: unclaimed spaces show 1–6 on game start
- [ ] Fortified mode: attacking an unclaimed space triggers dice roll
- [ ] Switching between Open/Fortified resets and re-seeds the board
- [ ] Mode persists when changing map size, player count, shape, or bot difficulty
- [ ] Score bar percentages are unaffected by unclaimed unit counts

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)