### PR TITLE
Refactor colors to CSS vars and add light/dark toggle v1.3.0 (#12, #13)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,12 +1,48 @@
+:root {
+  --page-bg-top:          #0d1b2a;
+  --page-bg-bottom:       #1a2f45;
+  --map-bg:               linear-gradient(145deg, #0096c7 0%, #0077b6 40%, #023e8a 100%);
+  --heading-color:        #e8c97a;
+  --setup-group-bg:       rgba(255, 255, 255, 0.05);
+  --setup-group-border:   rgba(232, 201, 122, 0.2);
+  --setup-label-color:    rgba(232, 201, 122, 0.65);
+  --sidebar-border:       #000;
+  --muted-text:           #dfdac0;
+  --footer-text:          rgba(255, 255, 255, 0.45);
+  --footer-link:          #4a9edd;
+  --version-color:        rgba(232, 201, 122, 0.65);
+  --version-border:       rgba(232, 201, 122, 0.3);
+  --version-hover-color:  rgba(232, 201, 122, 0.95);
+  --version-hover-border: rgba(232, 201, 122, 0.65);
+}
+
+[data-theme="light"] {
+  --page-bg-top:          #b8d4e8;
+  --page-bg-bottom:       #c8b99a;
+  --map-bg:               linear-gradient(145deg, #5ec9f0 0%, #3daed9 40%, #1a7ab5 100%);
+  --heading-color:        #5c3d10;
+  --setup-group-bg:       rgba(0, 0, 0, 0.06);
+  --setup-group-border:   rgba(92, 61, 16, 0.25);
+  --setup-label-color:    rgba(92, 61, 16, 0.7);
+  --sidebar-border:       rgba(92, 61, 16, 0.5);
+  --muted-text:           #5c3d10;
+  --footer-text:          rgba(50, 35, 15, 0.65);
+  --footer-link:          #0d5a8a;
+  --version-color:        rgba(92, 61, 16, 0.7);
+  --version-border:       rgba(92, 61, 16, 0.3);
+  --version-hover-color:  rgba(92, 61, 16, 1);
+  --version-hover-border: rgba(92, 61, 16, 0.65);
+}
+
 body{
-  background: linear-gradient(to bottom, #0d1b2a, #1a2f45);
+  background: linear-gradient(to bottom, var(--page-bg-top), var(--page-bg-bottom));
   min-height: 100vh;
   font-family: 'IM Fell English SC', serif;
 }
 H1{
   flex: 0 0 100%;
   text-align: center;
-  color: #e8c97a;
+  color: var(--heading-color);
   text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.7);
   margin-bottom: 0;
 }
@@ -17,7 +53,7 @@ h1 img{
 .map{
   padding: 28px;
   box-sizing: border-box;
-  background: linear-gradient(145deg, #0096c7 0%, #0077b6 40%, #023e8a 100%);
+  background: var(--map-bg);
   position:relative;
   max-width: 700px;
   width: 700px;
@@ -133,14 +169,14 @@ h1 img{
 }
 
 #round-counter {
-  color: #dfdac0;
+  color: var(--muted-text);
   font-size: 0.85em;
   padding: 4px 0 0;
   opacity: 0.8;
 }
 
 .side-bar{
-  border: 3px solid black;
+  border: 3px solid var(--sidebar-border);
   display: flex;
   margin: 10px 0 0 0;
   border-radius: 10px;
@@ -210,7 +246,7 @@ h1 img{
   text-align: center;
   padding: 10px 15px;
   font-size: 0.8em;
-  color: #dfdac0;
+  color: var(--muted-text);
 }
 
 #dice-attacker,
@@ -241,8 +277,8 @@ h1 img{
   flex-direction: column;
   align-items: center;
   gap: 5px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(232, 201, 122, 0.2);
+  background: var(--setup-group-bg);
+  border: 1px solid var(--setup-group-border);
   border-radius: 8px;
   padding: 6px 10px 8px;
 }
@@ -250,7 +286,7 @@ h1 img{
 .setup-label {
   font-family: 'IM Fell English SC', serif;
   font-size: 0.7em;
-  color: rgba(232, 201, 122, 0.65);
+  color: var(--setup-label-color);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -264,8 +300,8 @@ h1 img{
   gap: 5px;
 }
 
-/* Shared button base — all five types consolidated */
-.size-btn, .player-btn, .shape-btn, .island-btn, .bot-btn {
+/* Shared button base — all types consolidated */
+.size-btn, .player-btn, .shape-btn, .island-btn, .theme-btn, .bot-btn {
   font-family: 'IM Fell English SC', serif;
   font-size: 0.85em;
   padding: 5px 14px;
@@ -276,14 +312,14 @@ h1 img{
   box-shadow: inset 0 0 8px 1px rgba(0,0,0,0.5);
   color: #1a1a1a;
 }
-.size-btn:hover, .player-btn:hover, .shape-btn:hover, .island-btn:hover, .bot-btn:hover {
+.size-btn:hover, .player-btn:hover, .shape-btn:hover, .island-btn:hover, .theme-btn:hover, .bot-btn:hover {
   background-color: darkgoldenrod;
   color: #fff;
 }
-.size-btn:active, .player-btn:active, .shape-btn:active, .island-btn:active, .bot-btn:active {
+.size-btn:active, .player-btn:active, .shape-btn:active, .island-btn:active, .theme-btn:active, .bot-btn:active {
   transform: translate(2px, 2px);
 }
-.size-btn.active, .player-btn.active, .shape-btn.active, .island-btn.active, .bot-btn.active {
+.size-btn.active, .player-btn.active, .shape-btn.active, .island-btn.active, .theme-btn.active, .bot-btn.active {
   background-color: darkgoldenrod;
   color: #fff;
 }
@@ -450,25 +486,25 @@ h1 img{
   width: 100%;
   padding: 10px 20px;
   font-size: 0.75em;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--footer-text);
 }
 .footer a {
-  color: #4a9edd;
+  color: var(--footer-link);
 }
 #version {
   cursor: pointer;
   display: inline-block;
   font-size: 1rem;
-  color: rgba(232, 201, 122, 0.65);
-  border: 1px solid rgba(232, 201, 122, 0.3);
+  color: var(--version-color);
+  border: 1px solid var(--version-border);
   padding: 2px 10px;
   border-radius: 3px;
   letter-spacing: 0.08em;
   transition: color 0.15s, border-color 0.15s;
 }
 #version:hover {
-  color: rgba(232, 201, 122, 0.95);
-  border-color: rgba(232, 201, 122, 0.65);
+  color: var(--version-hover-color);
+  border-color: var(--version-hover-border);
   text-decoration: none;
 }
 
@@ -601,7 +637,7 @@ h1 img{
     padding: 5px 8px 6px;
   }
 
-  .size-btn, .bot-btn, .player-btn, .shape-btn, .island-btn {
+  .size-btn, .bot-btn, .player-btn, .shape-btn, .island-btn, .theme-btn {
     padding: 4px 10px;
     font-size: 0.8em;
   }
@@ -616,5 +652,5 @@ h1 img{
 @media (max-width: 400px) {
   #setup { gap: 5px; }
   .setup-group { padding: 4px 6px 5px; }
-  .size-btn, .bot-btn, .player-btn, .shape-btn, .island-btn { padding: 3px 7px; font-size: 0.75em; }
+  .size-btn, .bot-btn, .player-btn, .shape-btn, .island-btn, .theme-btn { padding: 3px 7px; font-size: 0.75em; }
 }

--- a/index.html
+++ b/index.html
@@ -45,6 +45,12 @@
           <button class="island-btn" data-mode="fortified">Fortified</button>
         </div>
       </div>
+      <div class="setup-group">
+        <span class="setup-label">Theme</span>
+        <div class="setup-btns">
+          <button id="theme-toggle" class="theme-btn">&#9728;</button>
+        </div>
+      </div>
       <div class="setup-group" id="bot-controls">
         <span class="setup-label">Bots</span>
         <div class="bot-rows">

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,13 @@
 'use strict';
 
-const VERSION = '1.2.0';
+const VERSION = '1.3.0';
 
 const CHANGELOG = `
+  <h3>v1.3.0 — 2026-03-05</h3>
+  <ul>
+    <li>Light/dark mode toggle with system preference detection and localStorage persistence</li>
+    <li>All colors refactored to CSS custom properties for clean theme switching</li>
+  </ul>
   <h3>v1.2.0 — 2026-03-05</h3>
   <ul>
     <li>Fortified Islands mode: unclaimed spaces start with 1–6 random defenders</li>
@@ -892,6 +897,23 @@ class Game {
         b.classList.toggle('active', b === btn));
       startGame(currentCols);
     });
+  });
+
+  // ── Theme toggle ───────────────────────────────────────
+  const themeToggle = document.getElementById('theme-toggle');
+
+  function applyTheme(theme) {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+    themeToggle.textContent = theme === 'light' ? '\u263D' : '\u2600';
+  }
+
+  const savedTheme = localStorage.getItem('theme') ||
+    (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+  applyTheme(savedTheme);
+
+  themeToggle.addEventListener('click', () => {
+    applyTheme(document.documentElement.dataset.theme === 'light' ? 'dark' : 'light');
   });
 
   updateBotControlVisibility(currentNumPlayers);


### PR DESCRIPTION
## Summary
- Extracts all themeable colors to `:root` CSS custom properties (page bg, map bg, heading, setup strip, sidebar border, muted text, footer, version badge)
- Adds `[data-theme="light"]` override block with a sandy/sky light palette
- Adds a sun/moon toggle button to the setup strip (Theme group)
- Reads `prefers-color-scheme` on first load; persists manual choice in `localStorage`
- Player colors, parchment panel textures, highlights, and warning colors unchanged

## Test plan
- [ ] Dark mode loads by default when system prefers dark
- [ ] Light mode loads by default when system prefers light
- [ ] Toggle button switches between ☀ (dark) and ☽ (light) icons
- [ ] Theme preference persists on page reload
- [ ] Toggling theme does NOT restart the game or deselect any setup buttons
- [ ] All setup button groups (Map Size, Players, Shape, Islands, Bots) unaffected by theme toggle

Closes #12
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)