### PR TITLE
Backfill changelog, tag missed releases, bump to v1.4.0 (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to GerdQuest: Isle Raid are documented here.
 
+## [1.4.0] - 2026-08-04
+
+### Changed
+- Renamed from "Island Pillaging" to **GerdQuest: Isle Raid**, adopting the GerdQuest series prefix
+- Page title, in-game heading, README and CHANGELOG updated to the new name
+- README live-site link corrected — it pointed at a domain this game has never deployed to
+
+## [1.3.0] - 2026-03-05
+
+### Added
+- Light/dark mode toggle with system preference detection and localStorage persistence (#13)
+
+### Changed
+- All colors refactored to CSS custom properties for clean theme switching (#12)
+
+## [1.2.0] - 2026-03-05
+
+### Added
+- Fortified Islands mode: unclaimed spaces start with 1–6 random defenders (#24)
+
 ## [1.1.1] - 2026-03-04
 
 ### Changed

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,15 @@
 'use strict';
 
-const VERSION = '1.3.0';
+const VERSION = '1.4.0';
 
+// Mirrors CHANGELOG.md — update both together when releasing.
+// Not generated from it: the game is meant to be opened as a local file, and
+// fetch() on file:// is blocked, so the notes have to be inlined here.
 const CHANGELOG = `
+  <h3>v1.4.0 — 2026-08-04</h3>
+  <ul>
+    <li>Renamed to GerdQuest: Isle Raid, adopting the GerdQuest series prefix</li>
+  </ul>
   <h3>v1.3.0 — 2026-03-05</h3>
   <ul>
     <li>Light/dark mode toggle with system preference detection and localStorage persistence</li>


### PR DESCRIPTION
Closes #40.

Restores the §6 versioning discipline — every release gets a version bump, a dated `CHANGELOG.md` section, and a `vX.Y.Z` tag.

## What was wrong

Three sources had drifted apart:

| Source | Said |
| --- | --- |
| `js/app.js` `VERSION` | `1.3.0` |
| `CHANGELOG.md` | `[1.1.1]` |
| git tags | `v1.1.1` |

So **v1.2.0** (Fortified Islands, #24) and **v1.3.0** (theme toggle, #12/#13) both shipped to Pages with no changelog section and no tag. On top of that, today's rename to GerdQuest: Isle Raid went to master unversioned — the deployed game has been serving the new name while reporting `v1.3.0` in the footer.

## What this does

- **`CHANGELOG.md`** — backfills `[1.2.0]` and `[1.3.0]`, dated 2026-03-05 from their commits, and adds `[1.4.0]` for the rename
- **Tags** — `v1.2.0` → `4d7a681`, `v1.3.0` → `cc36ba6`, already pushed. These point at the **feature** commits rather than the merge commits, matching the precedent set by `v1.1.1` → `91697a8`
- **`VERSION`** → `1.4.0`, with a matching entry in the in-app release-notes modal

## Notes

**Why 1.4.0 and not 2.0.0.** The rename is user-visible but nothing breaks — no save format, no API, no URL change. Minor. (For contrast, Realm of Depths took its rename to 4.0.0, but that release carried other work.)

**The modal is still hand-maintained.** #40 asked for one source of truth instead of two lists. I didn't build that: the only no-build option is `fetch('CHANGELOG.md')`, and the game is meant to be opened directly as a local file, where `fetch()` on `file://` is blocked by CORS. That would trade a sync problem for a broken release-notes panel in the project's primary way of running. There's now a comment in `js/app.js` recording the constraint. If #41 introduces a build step, generating the modal at build time becomes the right fix — worth revisiting there.

**`v1.4.0` is not tagged yet.** It should land on the commit that ends up on master, so it's better created after this merges than on a branch commit that may not survive the merge strategy.

**Merge strategy.** §6 asks for rebase-merge and linear history; this repo has been using merge commits (`06f5284`, `3a0820a`). Not changed here — flagged in #40 as a separate call.
