### PR TITLE
Fit the whole game on one screen, v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to GerdQuest: Isle Raid are documented here.
 
+## [1.8.0] - 2026-08-05
+
+### Changed
+- The game fits one screen. `.container` is a three-column grid — wordmark and setup strip across the top, board and sidebar below, footer at the foot — and the body no longer scrolls above 680px wide
+- The board is square and sized from whichever dimension of its cell is smaller, using container query units, so it fills the height available rather than sitting at a fixed 700px. No resize listener and no hardcoded guess at how tall the chrome is
+- Island numbers scale with the board, so a 6×6 on a laptop still reads
+- The sidebar scrolls inside itself on short screens instead of pushing the page down
+- Under 680px the one-screen layout is dropped on purpose: the layout stacks and the page scrolls, which is the right shape for a phone
+
+### Fixed
+- Hex and triangle cells are pixel-sized in JS, so they went stale whenever the window changed. They are now recomputed in place on resize — the game keeps its state, the board just refits
+
 ## [1.7.0] - 2026-08-05
 
 ### Changed

--- a/css/style.css
+++ b/css/style.css
@@ -95,6 +95,10 @@
   --version-border:       rgba(184, 134, 47, 0.35);
   --version-hover-color:  var(--gold-bright);
   --version-hover-border: var(--gold);
+
+  /* Fixed-width flanks of the one-screen grid; the map takes the rest. */
+  --col-word: 260px;
+  --col-side: 240px;
 }
 
 /* §3: the focus ring is always visible and never removed. */
@@ -103,9 +107,16 @@
   outline-offset: 2px;
 }
 
+/* ── One-screen shell ──────────────────────────────────────
+   The whole game fits the viewport: the body never scrolls, and
+   every region that can outgrow its cell scrolls inside itself.
+   Below 680px this is abandoned deliberately — see the phone
+   breakpoint, where stacking and scrolling beat cramming.     */
 body{
   background: linear-gradient(to bottom, var(--bg-1), var(--bg-0));
-  min-height: 100vh;
+  margin: 0;
+  height: 100dvh;
+  overflow: hidden;
   font-family: var(--font-body);
 }
 /* ── Wordmark (bible §2) ───────────────────────────────────
@@ -118,11 +129,13 @@ body{
    The full title always travels together — a live Google Play
    island-conquest game owns the bare name "Isle Raid" (#43).   */
 .wordmark {
-  flex: 0 0 100%;
+  grid-area: word;
+  align-self: center;
   text-align: center;
+  min-width: 0;
 }
 .wordmark h1 {
-  margin: 0 0 4px;
+  margin: 0;
   font-family: var(--font-display);
   font-size: 2.1rem;
   font-weight: 400;
@@ -148,32 +161,57 @@ body{
   margin-right: 10px;
   filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.35));
 }
+/* The cell the map lives in. `container-type: size` makes its own
+   measured width and height queryable as cqw/cqh, which is what lets
+   the square board pick the smaller of the two in pure CSS — no
+   resize listener, no magic number for the chrome above it. */
+.map-area {
+  grid-area: map;
+  container-type: size;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
 .map{
-  padding: 28px;
+  padding: clamp(10px, 3cqmin, 28px);
   box-sizing: border-box;
   background: var(--map-bg);
   position:relative;
-  max-width: 700px;
-  width: 700px;
-  height: 700px;
+  width:  min(100cqw, 100cqh);
+  height: min(100cqw, 100cqh);
   border-radius: 5%;
   display: grid;
   grid-template-columns: repeat(var(--grid-cols, 4), 1fr);
-  gap: 12px;
+  gap: clamp(5px, 1.4cqmin, 12px);
   align-content: center;
-  margin: 10px 20px 40px 0;
+  margin: 0;
   overflow: hidden;
 }
 .container {
-  margin: auto;
-  display: flex;
-  justify-content: center;
-  flex-direction: row;
-  flex-wrap: wrap;
-  max-width: 980px;
-  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, var(--col-word)) minmax(0, 1fr) var(--col-side);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    "word top  top"
+    "map  map  side"
+    "foot foot foot";
+  gap: 6px 14px;
+  height: 100dvh;
+  max-width: 1600px;
+  margin: 0 auto;
   box-sizing: border-box;
-  padding: 10px 12px 30px;
+  padding: 8px 14px 4px;
+}
+
+#top-bar {
+  grid-area: top;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
 }
 
 .space {
@@ -192,6 +230,9 @@ body{
 }
 .space h2 {
   margin: 0;
+  /* Scales with the board, so a 6×6 on a short screen still reads as
+     a number rather than overflowing its island. */
+  font-size: clamp(0.8rem, calc(14cqmin / var(--grid-cols, 4)), 1.9rem);
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.7);
   color: #f0ece0;
   /* A number the player counts — §3 wants these mono and tabular. */
@@ -295,15 +336,19 @@ body{
 }
 
 .side-bar{
+  grid-area: side;
   border: 3px solid var(--gold);
   display: flex;
-  margin: 10px 0 0 0;
+  margin: 0;
   border-radius: 10px;
   flex-direction: column;
   justify-content: flex-start;
-  align-self: flex-start;
-  width: 230px;
-  overflow: hidden;
+  align-self: stretch;
+  width: auto;
+  min-height: 0;
+  /* Taller than its cell on a short screen — scroll here, not the page. */
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .button:active {
@@ -330,7 +375,9 @@ body{
 .rules{
   width: 100%;
   box-sizing: border-box;
-  min-height: 200px;
+  /* Takes the slack so the parchment runs to the foot of the sidebar. */
+  flex: 1 1 auto;
+  min-height: 120px;
   background: url(../images/largeimage.jpg);
   border: none;
   text-align: center;
@@ -391,15 +438,14 @@ body{
 }
 
 #setup {
-  flex: 0 0 100%;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: center;
-  gap: 8px;
-  padding: 10px 16px;
-  margin-bottom: 4px;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
 }
 
 .setup-group {
@@ -481,12 +527,12 @@ body{
 
 /* ── Score bar ─────────────────────────────────── */
 #score-bar {
-  flex: 0 0 100%;
   display: flex;
-  height: 14px;
+  flex: 0 0 auto;
+  height: 12px;
   border-radius: 4px;
   overflow: hidden;
-  margin: 0 0 6px;
+  margin: 0;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
@@ -612,9 +658,10 @@ body{
 }
 
 .footer {
+  grid-area: foot;
   box-sizing: border-box;
   width: 100%;
-  padding: 10px 20px;
+  padding: 4px 6px 2px;
   font-size: 0.75em;
   color: var(--footer-text);
 }
@@ -733,35 +780,89 @@ body{
 }
 
 /* ── Responsive breakpoints ───────────────────── */
-@media (max-width: 960px) {
-  .map {
-    width: calc(100% - 254px);
-    height: auto;
-    aspect-ratio: 1;
-    margin: 10px 12px 20px 0;
+
+/* Short screens: the chrome gives up height before the board does. */
+@media (max-height: 820px) {
+  .wordmark h1     { font-size: 1.65rem; }
+  .wordmark img    { width: 48px; margin-right: 8px; }
+  .button          { padding: 14px 15px; }
+  .turns           { padding: 8px 15px; }
+  .scores          { padding: 8px 15px; }
+  .setup-group     { padding: 4px 8px 5px; }
+  .size-btn, .player-btn, .shape-btn, .island-btn, .bot-btn {
+    padding: 3px 11px;
   }
 }
 
+@media (max-width: 1100px) {
+  :root { --col-word: 210px; --col-side: 210px; }
+}
+
+@media (max-width: 900px) {
+  /* Not enough width for a wordmark column — give the whole top row
+     to the setup strip and let the title sit above it. */
+  .container {
+    grid-template-columns: minmax(0, 1fr) var(--col-side);
+    grid-template-areas:
+      "word word"
+      "top  top"
+      "map  side"
+      "foot foot";
+    grid-template-rows: auto auto minmax(0, 1fr) auto;
+  }
+}
+
+/* Phones: stop pretending one screen is the right shape. Stack it,
+   let the page scroll, and size the board from its width alone. */
 @media (max-width: 680px) {
+  body {
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
+  }
+
+  .container {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "word"
+      "top"
+      "map"
+      "side"
+      "foot";
+    grid-template-rows: auto auto auto auto auto;
+    height: auto;
+    gap: 10px 0;
+    padding: 10px 12px 20px;
+  }
+
+  .map-area {
+    container-type: inline-size;
+    overflow: visible;
+  }
+
   .map {
     width: 100%;
-    max-width: 100%;
     height: auto;
     aspect-ratio: 1;
-    margin: 10px 0 16px 0;
     padding: 16px;
+    gap: 8px;
+  }
+
+  /* Width-only container here, so cqmin has no height axis to read. */
+  .space h2 {
+    font-size: clamp(0.8rem, calc(14cqw / var(--grid-cols, 4)), 1.9rem);
   }
 
   .side-bar {
     width: 100%;
-    flex: 0 0 100%;
-    margin: 0 0 20px 0;
+    margin: 0;
+    overflow: visible;
     border-radius: 10px;
   }
 
   #setup {
     gap: 6px;
-    padding: 6px 8px;
+    padding: 0;
   }
 
   .setup-group {

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
   <script src="js/vendor/sweetalert2.min.js"></script>
 </head>
 <body>
+  <!-- One screen, no page scroll. `.container` is a three-column grid:
+       wordmark | setup+score bar across the top, map | side-bar below,
+       footer across the foot. The footer lives inside the container so
+       the grid owns the whole viewport height. -->
   <div class="container">
 
     <div class="wordmark">
@@ -18,72 +22,82 @@
         <img src="images/flag.png" alt="">Isle Raid
       </h1>
     </div>
-    <div id="setup">
-      <div class="setup-group">
-        <span class="setup-label">Map Size</span>
-        <div class="setup-btns">
-          <button class="size-btn active" data-cols="4">4 × 4</button>
-          <button class="size-btn" data-cols="5">5 × 5</button>
-          <button class="size-btn" data-cols="6">6 × 6</button>
-        </div>
-      </div>
-      <div class="setup-group">
-        <span class="setup-label">Players</span>
-        <div class="setup-btns">
-          <button class="player-btn active" data-num="2">2</button>
-          <button class="player-btn" data-num="3">3</button>
-          <button class="player-btn" data-num="4">4</button>
-        </div>
-      </div>
-      <div class="setup-group">
-        <span class="setup-label">Shape</span>
-        <div class="setup-btns">
-          <button class="shape-btn active" data-shape="square">Square</button>
-          <button class="shape-btn" data-shape="hex">Hex</button>
-          <button class="shape-btn" data-shape="triangle">Triangle</button>
-        </div>
-      </div>
-      <div class="setup-group">
-        <span class="setup-label">Islands</span>
-        <div class="setup-btns">
-          <button class="island-btn active" data-mode="open">Open</button>
-          <button class="island-btn" data-mode="fortified">Fortified</button>
-        </div>
-      </div>
-      <div class="setup-group" id="bot-controls">
-        <span class="setup-label">Bots</span>
-        <div class="bot-rows">
-          <div class="bot-row">
-            <span class="bot-player-label bot-p2">P2</span>
-            <button class="bot-btn active" data-player="2" data-diff="off">Off</button>
-            <button class="bot-btn" data-player="2" data-diff="easy">Easy</button>
-            <button class="bot-btn" data-player="2" data-diff="medium">Med</button>
-            <button class="bot-btn" data-player="2" data-diff="hard">Hard</button>
-          </div>
-          <div class="bot-row p3-control">
-            <span class="bot-player-label bot-p3">P3</span>
-            <button class="bot-btn active" data-player="3" data-diff="off">Off</button>
-            <button class="bot-btn" data-player="3" data-diff="easy">Easy</button>
-            <button class="bot-btn" data-player="3" data-diff="medium">Med</button>
-            <button class="bot-btn" data-player="3" data-diff="hard">Hard</button>
-          </div>
-          <div class="bot-row p4-control">
-            <span class="bot-player-label bot-p4">P4</span>
-            <button class="bot-btn active" data-player="4" data-diff="off">Off</button>
-            <button class="bot-btn" data-player="4" data-diff="easy">Easy</button>
-            <button class="bot-btn" data-player="4" data-diff="medium">Med</button>
-            <button class="bot-btn" data-player="4" data-diff="hard">Hard</button>
+
+    <div id="top-bar">
+      <div id="setup">
+        <div class="setup-group">
+          <span class="setup-label">Map Size</span>
+          <div class="setup-btns">
+            <button class="size-btn active" data-cols="4">4 × 4</button>
+            <button class="size-btn" data-cols="5">5 × 5</button>
+            <button class="size-btn" data-cols="6">6 × 6</button>
           </div>
         </div>
+        <div class="setup-group">
+          <span class="setup-label">Players</span>
+          <div class="setup-btns">
+            <button class="player-btn active" data-num="2">2</button>
+            <button class="player-btn" data-num="3">3</button>
+            <button class="player-btn" data-num="4">4</button>
+          </div>
+        </div>
+        <div class="setup-group">
+          <span class="setup-label">Shape</span>
+          <div class="setup-btns">
+            <button class="shape-btn active" data-shape="square">Square</button>
+            <button class="shape-btn" data-shape="hex">Hex</button>
+            <button class="shape-btn" data-shape="triangle">Triangle</button>
+          </div>
+        </div>
+        <div class="setup-group">
+          <span class="setup-label">Islands</span>
+          <div class="setup-btns">
+            <button class="island-btn active" data-mode="open">Open</button>
+            <button class="island-btn" data-mode="fortified">Fortified</button>
+          </div>
+        </div>
+        <div class="setup-group" id="bot-controls">
+          <span class="setup-label">Bots</span>
+          <div class="bot-rows">
+            <div class="bot-row">
+              <span class="bot-player-label bot-p2">P2</span>
+              <button class="bot-btn active" data-player="2" data-diff="off">Off</button>
+              <button class="bot-btn" data-player="2" data-diff="easy">Easy</button>
+              <button class="bot-btn" data-player="2" data-diff="medium">Med</button>
+              <button class="bot-btn" data-player="2" data-diff="hard">Hard</button>
+            </div>
+            <div class="bot-row p3-control">
+              <span class="bot-player-label bot-p3">P3</span>
+              <button class="bot-btn active" data-player="3" data-diff="off">Off</button>
+              <button class="bot-btn" data-player="3" data-diff="easy">Easy</button>
+              <button class="bot-btn" data-player="3" data-diff="medium">Med</button>
+              <button class="bot-btn" data-player="3" data-diff="hard">Hard</button>
+            </div>
+            <div class="bot-row p4-control">
+              <span class="bot-player-label bot-p4">P4</span>
+              <button class="bot-btn active" data-player="4" data-diff="off">Off</button>
+              <button class="bot-btn" data-player="4" data-diff="easy">Easy</button>
+              <button class="bot-btn" data-player="4" data-diff="medium">Med</button>
+              <button class="bot-btn" data-player="4" data-diff="hard">Hard</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="score-bar">
+        <div class="score-segment" id="seg-player1"></div>
+        <div class="score-segment" id="seg-player2"></div>
+        <div class="score-segment" id="seg-player3"></div>
+        <div class="score-segment" id="seg-player4"></div>
       </div>
     </div>
-    <div id="score-bar">
-      <div class="score-segment" id="seg-player1"></div>
-      <div class="score-segment" id="seg-player2"></div>
-      <div class="score-segment" id="seg-player3"></div>
-      <div class="score-segment" id="seg-player4"></div>
+
+    <!-- The map is square and sized from whichever of this cell's two
+         dimensions is smaller, so it fills the height it is given
+         without ever pushing the page past one screen. -->
+    <div class="map-area">
+      <div class="map"></div>
     </div>
-    <div class="map"></div>
+
     <div class="side-bar">
       <button class="button" id="end-phase-btn">⚔ End Attack</button>
       <div class="turns">
@@ -100,11 +114,12 @@
       <div class="rules"></div>
       <div id="warning" hidden></div>
     </div>
-  </div>
-  <div class="footer">
-    <a href="https://nerdytoddgerdy.github.io/nerdy-gerdy-games/">More Games</a>
-    &nbsp;·&nbsp;
-    <span id="version"></span>
+
+    <div class="footer">
+      <a href="https://nerdytoddgerdy.github.io/nerdy-gerdy-games/">More Games</a>
+      &nbsp;·&nbsp;
+      <span id="version"></span>
+    </div>
   </div>
 
   <div id="changelog-modal" hidden>

--- a/js/app.js
+++ b/js/app.js
@@ -1,11 +1,17 @@
 'use strict';
 
-const VERSION = '1.7.0';
+const VERSION = '1.8.0';
 
 // Mirrors CHANGELOG.md — update both together when releasing.
 // Not generated from it: the game is meant to be opened as a local file, and
 // fetch() on file:// is blocked, so the notes have to be inlined here.
 const CHANGELOG = `
+  <h3>v1.8.0 — 2026-08-05</h3>
+  <ul>
+    <li>The whole game now fits one screen — no scrolling to see the board and the sidebar together</li>
+    <li>The board grows and shrinks with your window instead of sitting at a fixed size</li>
+    <li>Phones still scroll, which is the right thing there</li>
+  </ul>
   <h3>v1.7.0 — 2026-08-05</h3>
   <ul>
     <li>All in-game text rewritten — plainer, and it now tells you how combat actually resolves</li>
@@ -111,6 +117,19 @@ document.addEventListener('DOMContentLoaded', () => {
     activeGame.init();
   }
 
+  // The board is sized from the viewport, so hex and triangle cells —
+  // which are pixel-sized in JS — go stale when the window changes.
+  // Resize in place rather than rebuilding: a rebuild would reset the game.
+  // One listener for the page's lifetime; games come and go beneath it.
+  let resizeFrame = null;
+  window.addEventListener('resize', () => {
+    if (resizeFrame) cancelAnimationFrame(resizeFrame);
+    resizeFrame = requestAnimationFrame(() => {
+      resizeFrame = null;
+      if (activeGame) activeGame.applyShapeMetrics();
+    });
+  });
+
 class Game {
   constructor(cols = 4, diff = {}, numPlayers = 2, shape = 'square', islandMode = 'open') {
     this.cols      = cols;
@@ -150,16 +169,16 @@ class Game {
 
   // ── Bootstrap ──────────────────────────────────────────
 
-  buildGrid() {
-    this.mapEl.innerHTML = '';
+  // Hex and triangle cells are pixel-sized from the map's measured box,
+  // and the map is now sized from the viewport, so every recomputation
+  // has to be repeatable — on build and on resize alike. The square
+  // grid needs none of this: its columns are `1fr`.
+  applyShapeMetrics() {
+    const pad = parseInt(getComputedStyle(this.mapEl).paddingLeft, 10) || 28;
+    const contentW = this.mapEl.clientWidth - 2 * pad;
+    if (contentW <= 0) return;                 // laid out to nothing — nothing to size
 
     if (this.shape === 'hex') {
-      this.mapEl.classList.add('hex-mode');
-      this.mapEl.classList.remove('tri-mode');
-
-      // Dynamically size hexes to fill the actual rendered map width
-      const pad = parseInt(getComputedStyle(this.mapEl).paddingLeft, 10) || 28;
-      const contentW = this.mapEl.offsetWidth - 2 * pad;
       // Width constraint: odd rows span w*(cols+0.5) ≤ contentW
       const wByWidth  = Math.floor(contentW / (this.cols + 0.5));
       // Height constraint: total height = h*(3*cols+1)/4 ≤ contentW (map is square)
@@ -173,6 +192,43 @@ class Game {
       this.mapEl.style.setProperty('--hex-gap',        '0px');
       this.mapEl.style.setProperty('--hex-row-offset', '-' + (h / 4) + 'px');
       this.mapEl.style.setProperty('--hex-half-w',     (w / 2) + 'px');
+
+    } else if (this.shape === 'triangle') {
+      // Width constraint: row_w = w*(cols+1)/2 ≤ contentW → w ≤ 2*contentW/(cols+1)
+      const wByWidth  = Math.floor(2 * contentW / (this.cols + 1));
+      // Height constraint: h*cols ≤ contentW, h = w*0.866 → w ≤ contentW/(0.866*cols)
+      const wByHeight = Math.floor(contentW / (0.866 * this.cols));
+      const w = Math.min(wByWidth, wByHeight);
+      const h = Math.round(w * 0.866);
+
+      this.mapEl.style.setProperty('--tri-w',       w + 'px');
+      this.mapEl.style.setProperty('--tri-h',       h + 'px');
+      this.mapEl.style.setProperty('--tri-row-w',   Math.round(w * (this.cols + 1) / 2) + 'px');
+      this.mapEl.style.setProperty('--tri-total-h', (h * this.cols) + 'px');
+      this.triW = w;
+      this.triH = h;
+
+      // Triangles are absolutely positioned, so they move with the size.
+      for (let r = 0; r < this.cols; r++) {
+        for (let c = 0; c < this.cols; c++) {
+          const el = document.getElementById(`space-${r * this.cols + c}`);
+          if (!el) continue;
+          el.style.left = (c * w / 2) + 'px';
+          el.style.top  = (r * h) + 'px';
+        }
+      }
+    }
+  }
+
+  buildGrid() {
+    this.mapEl.innerHTML = '';
+    // Read by the island-number font scale in CSS, in every shape.
+    this.mapEl.style.setProperty('--grid-cols', this.cols);
+
+    if (this.shape === 'hex') {
+      this.mapEl.classList.add('hex-mode');
+      this.mapEl.classList.remove('tri-mode');
+      this.applyShapeMetrics();
 
       const wrapper = document.createElement('div');
       wrapper.className = 'hex-grid-wrapper';
@@ -195,25 +251,6 @@ class Game {
       this.mapEl.classList.add('tri-mode');
       this.mapEl.classList.remove('hex-mode');
 
-      // Dynamically size triangles to fill the actual rendered map width
-      const pad = parseInt(getComputedStyle(this.mapEl).paddingLeft, 10) || 28;
-      const contentW = this.mapEl.offsetWidth - 2 * pad;
-      // Width constraint: row_w = w*(cols+1)/2 ≤ contentW → w ≤ 2*contentW/(cols+1)
-      const wByWidth  = Math.floor(2 * contentW / (this.cols + 1));
-      // Height constraint: h*cols ≤ contentW, h = w*0.866 → w ≤ contentW/(0.866*cols)
-      const wByHeight = Math.floor(contentW / (0.866 * this.cols));
-      const w = Math.min(wByWidth, wByHeight);
-      const h = Math.round(w * 0.866);
-      const rowW   = Math.round(w * (this.cols + 1) / 2);
-      const totalH = h * this.cols;
-
-      this.mapEl.style.setProperty('--tri-w',       w + 'px');
-      this.mapEl.style.setProperty('--tri-h',       h + 'px');
-      this.mapEl.style.setProperty('--tri-row-w',   rowW + 'px');
-      this.mapEl.style.setProperty('--tri-total-h', totalH + 'px');
-      this.triW = w;
-      this.triH = h;
-
       const wrapper = document.createElement('div');
       wrapper.className = 'tri-grid-wrapper';
 
@@ -224,17 +261,16 @@ class Game {
           div.className = 'space';
           div.id = `space-${r * this.cols + c}`;
           div.dataset.orientation = orientation;
-          div.style.left = (c * w / 2) + 'px';
-          div.style.top  = (r * h) + 'px';
           div.innerHTML = '<h2>0</h2>';
           wrapper.appendChild(div);
         }
       }
       this.mapEl.appendChild(wrapper);
+      // Sizes and places the triangles now that they are in the document.
+      this.applyShapeMetrics();
 
     } else {
       this.mapEl.classList.remove('hex-mode', 'tri-mode');
-      this.mapEl.style.setProperty('--grid-cols', this.cols);
 
       for (let i = 0; i < this.gridSize; i++) {
         const div = document.createElement('div');


### PR DESCRIPTION
The board sat at a fixed 700px with the sidebar beside it and the footer below, so anything shorter than a desktop monitor scrolled. Now the whole game fits the viewport.

## Layout

`.container` is a three-column grid — wordmark | setup + score bar across the top, board | sidebar below, footer at the foot. The footer moves inside the container so the grid owns the full viewport height, and `#setup` / `#score-bar` share a `#top-bar` wrapper.

## Board sizing

`.map-area` is a `container-type: size` cell, which lets the square board be `min(100cqw, 100cqh)` — whichever of its cell's two dimensions is smaller. It fills the height left over after the chrome with **no resize listener and no hardcoded guess at how tall that chrome is**. Island numbers scale with the board (`14cqmin / --grid-cols`), so a 6×6 on a laptop still reads.

Overflow goes where it belongs: the sidebar scrolls inside itself on a short screen rather than pushing the page down.

## Phones

Below 680px the one-screen rule is dropped on purpose — the layout stacks and the page scrolls. Cramming a board plus a sidebar into a phone screen makes both unusable. It's commented in the CSS so it doesn't get "fixed" later.

## Fixed

Hex and triangle cells are pixel-sized in JS, which the old fixed-size board hid — they went stale whenever the window changed. The math is extracted to `applyShapeMetrics()` and re-run from a debounced resize listener, **in place**: a rebuild would reset the game.

## Testing

Driven in headless Chrome, not eyeballed:

- No page scroll at 1920×1080, 1440×900, 1366×768, 1280×800, 1024×640 (`scrollHeight == clientHeight`, same for width). Board lands between 860px and 370px.
- No overflow with hex boards, triangle boards, 6×6, or 4 players — the combinations that make the setup strip tallest.
- Select-and-attack drives correctly in all three shapes; a fortified attack rolls dice and reports the outcome, which also exercises the v1.7.0 copy and colour change.
- Phone layout stacks and scrolls.

## Release

Player-facing, so §6 in full: `VERSION` 1.8.0, dated `CHANGELOG.md` section, matching release-notes modal entry, tag `v1.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)