### PR TITLE
Widen the sidebar, v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to GerdQuest: Isle Raid are documented here.
 
+## [1.8.1] - 2026-08-05
+
+### Changed
+- Sidebar widened from 240px to 310px (260px below 1100px wide). The rules panel and dice readout were setting in narrow, ragged lines
+- The board is unaffected at every size checked: it is limited by the height left after the chrome, not by width, so the sidebar took the empty space beside it rather than any of the board
+
 ## [1.8.0] - 2026-08-05
 
 ### Changed

--- a/css/style.css
+++ b/css/style.css
@@ -98,7 +98,7 @@
 
   /* Fixed-width flanks of the one-screen grid; the map takes the rest. */
   --col-word: 260px;
-  --col-side: 240px;
+  --col-side: 310px;
 }
 
 /* §3: the focus ring is always visible and never removed. */
@@ -795,7 +795,7 @@ body{
 }
 
 @media (max-width: 1100px) {
-  :root { --col-word: 210px; --col-side: 210px; }
+  :root { --col-word: 210px; --col-side: 260px; }
 }
 
 @media (max-width: 900px) {

--- a/js/app.js
+++ b/js/app.js
@@ -1,11 +1,15 @@
 'use strict';
 
-const VERSION = '1.8.0';
+const VERSION = '1.8.1';
 
 // Mirrors CHANGELOG.md — update both together when releasing.
 // Not generated from it: the game is meant to be opened as a local file, and
 // fetch() on file:// is blocked, so the notes have to be inlined here.
 const CHANGELOG = `
+  <h3>v1.8.1 — 2026-08-05</h3>
+  <ul>
+    <li>Wider sidebar — the rules and dice readout no longer set in narrow ragged lines. The board is unchanged; the width came from empty space beside it</li>
+  </ul>
   <h3>v1.8.0 — 2026-08-05</h3>
   <ul>
     <li>The whole game now fits one screen — no scrolling to see the board and the sidebar together</li>


### PR DESCRIPTION
240px was tight enough that the rules panel and the dice readout set in narrow, ragged lines. Now **310px**, and 260px below 1100px wide.

## It costs the board nothing

The board is square and limited by the height left after the chrome, not by the width of its column — so the extra 70px came out of the empty space beside the board rather than out of the board. Measured, not assumed:

| Viewport | Board before | Board after |
| --- | --- | --- |
| 1920×1080 | 860 | 860 |
| 1440×900 | 689 | 689 |
| 1366×768 | 557 | 557 |
| 1280×800 | 530 | 530 |
| 1024×640 | 370 | 370 |

No page scroll at any of them.

Side benefit at 1280×800: the sidebar no longer has to scroll inside itself, because wider text wraps less.

## Release

Player-facing, so §6 in full: `VERSION` 1.8.1, dated `CHANGELOG.md` section, matching release-notes modal entry, tag `v1.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)